### PR TITLE
Add CEntryExitManager::Update disable patch

### DIFF
--- a/Client/Core/Hooks/HookGameLogic.cpp
+++ b/Client/Core/Hooks/HookGameLogic.cpp
@@ -78,6 +78,9 @@ static HookFunction hookFunction([]()
 
     // Disable CShopping::LoadStats
     MakeRET(0x49B6A0);
+    
+    // Disable CEntryExitManager::Update
+    MakeRET(0x440D10);
 
     // Stop CTaskSimpleCarDrive::ProcessPed from exiting passengers with CTaskComplexSequence
     MakeNOP(0x644C18);


### PR DESCRIPTION
Enex markers lead to desyncs and crashes.

**Steps which explain the enhancement**

1. Disable them completely

**Screenshots, YouTube videos and GIFs**

![Screenshot](https://cdn.pbrd.co/images/22idQCh8Y.png)

**CTNorth Version:** v0.1.0-alpha
**OS and Version:** Windows 10 (version 1607)