### PR TITLE
Avoid mention-bot errors on JSON comments

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,19 +1,19 @@
 {
-  "maxReviewers": 5, // Maximum  number of people to ping in the PR message, default is 3
-  "numFilesToCheck": 10, // Number of files to check against, default is 5
-  "findPotentialReviewers": true, // mention-bot will try to find potential reviewers based on files history, if disabled, `alwaysNotifyForPaths` is used instead
-  "fileBlacklist": ["*.md"], // mention-bot will ignore any files that match these file globs
-  "userBlacklist": [], // Users in this list will never be mentioned by mention-bot
-  "userBlacklistForPR": [], // PR made by users in this list will be ignored
-  "requiredOrgs": [], // mention-bot will only mention user who are a member of one of these organizations
-  "actions": ["opened"], // List of PR actions that mention-bot will listen to, default is "opened"
-  "skipAlreadyAssignedPR": false, // mention-bot will ignore already assigned PR's
-  "skipAlreadyMentionedPR": false, // mention-bot will ignore if there is already existing an exact mention
-  "assignToReviewer": false, // mention-bot assigns the most appropriate reviewer for PR
-  "createReviewRequest": false, // mention-bot creates review request for the most appropriate reviewer for PR
-  "skipTitle": "", // mention-bot will ignore PR that includes text in the title,
-  "withLabel": "", // mention-bot will only consider PR's with this label. Must set actions to ["labeled"].
-  "delayed": false, // mention-bot will wait to comment until specified time in `delayedUntil` value
-  "delayedUntil": "3d", // Used if delayed is equal true, permitted values are: minutes, hours, or days, e.g.: '3 days', '40 minutes', '1 hour', '3d', '1h', '10m'
-  "skipCollaboratorPR": false // mention-bot will ignore if PR is made by collaborator
+  "maxReviewers": 5,
+  "numFilesToCheck": 10,
+  "findPotentialReviewers": true,
+  "fileBlacklist": ["*.md"],
+  "userBlacklist": [],
+  "userBlacklistForPR": [],
+  "requiredOrgs": [],
+  "actions": ["opened"],
+  "skipAlreadyAssignedPR": false,
+  "skipAlreadyMentionedPR": false,
+  "assignToReviewer": false,
+  "createReviewRequest": false,
+  "skipTitle": "",
+  "withLabel": "",
+  "delayed": false,
+  "delayedUntil": "3d",
+  "skipCollaboratorPR": false
 }


### PR DESCRIPTION
Mention bot fails to parse JSON comments, so remove them.